### PR TITLE
Made the menu icons oute to the home path on click

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -1,6 +1,6 @@
 <template>
     <v-toolbar color="theme_darkBlue">
-        <v-app-bar-nav-icon>
+        <v-app-bar-nav-icon to="/">
             <img
                 alt="Vue logo"
                 src="../assets/logo/Amplify-Email.png"
@@ -8,7 +8,12 @@
             />
         </v-app-bar-nav-icon>
 
-        <v-toolbar-title class="white--text text-h6">AMPLIFY</v-toolbar-title>
+        <v-toolbar-title
+            class="white--text text-h6"
+            @click="$router.push('/')"
+            style="cursor:pointer"
+            >
+            AMPLIFY</v-toolbar-title>
 
         <v-spacer></v-spacer>
 


### PR DESCRIPTION
Amplify Logo* and *Amplify title* are now routable and clickable
- Used @click method along with `$router.push` to route users back to the home page on click
- Used `to="/"` for the same functionality as above

(Meant to PR from fork, but the codespace decided otherwise)